### PR TITLE
Fix CODE_OF_CONDUCT.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ An [open book about Jupyter and its use in teaching and learning](https://jupyte
 Please note that this project is released with a Contributor Code of Conduct
 based on the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 The full code of conduct is available in the
-[CODE_OF_CONDUCT.md](https://github.com/barbagroup/jupyter-edu-book/blob/master/CODE-OF-CONDUCT.md)
+[CODE_OF_CONDUCT.md](CODE-OF-CONDUCT.md)
 file. By participating in this project you agree to abide by its terms.


### PR DESCRIPTION
It didn't need to be a full URL, and it pointed to the wrong place.