### PR TITLE
Unicode doesn't work in PDF

### DIFF
--- a/05-jupyter-ecosystem.md
+++ b/05-jupyter-ecosystem.md
@@ -374,7 +374,7 @@ curriculum.
 
 ## Gotchas
 
-### Programming language ≠ Jupyter
+### Programming language $\neq$ Jupyter
 
 Teaching a class entirely with Jupyter can give the sense to students
 that this is the way all computational exploration is done. In

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,3 +243,9 @@ Please feel free to add to or edit these sections.
 We use markdown for the book formatting.
 
 - Citations: https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html
+
+If possible, avoid using unicode characters as they don't always
+transfer well into the document formats possible (HTML, PDF, etc.)
+Often, you might be able to find unicode replacements by using LaTeX
+math symbols and surrounding them by dollar signs (for example, $\neq$
+will render as ≠).


### PR DESCRIPTION
This PR replaces the unicode for "not equal" with the LaTeX mathmode equivalent, which seems to work better for different types of output.