### PR TITLE
Manual copy of icons to gh-pages

### DIFF
--- a/_deploy.sh
+++ b/_deploy.sh
@@ -11,6 +11,12 @@ git config --global user.name "Kyle Niemeyer"
 git clone -b gh-pages https://${GITHUB_PAT}@github.com/${TRAVIS_REPO_SLUG}.git book-output
 cd book-output
 cp -r ../_book/* ./
+## Manual copies to get the icons:
+cp ../images/caution.png ./images
+cp ../images/important.png ./images
+cp ../images/note.png ./images
+cp ../images/tip.png ./images
+cp ../images/warning.png ./images
 git add --all *
 git commit -m"Update the book" || true
 git push -q origin gh-pages


### PR DESCRIPTION
The icons are not being copied to the gh-pages, because I suspect that they are not being processed by R. So we manually copy them in the _deploy.sh script.