### PR TITLE
Fix icon paths

### DIFF
--- a/_deploy.sh
+++ b/_deploy.sh
@@ -11,12 +11,6 @@ git config --global user.name "Kyle Niemeyer"
 git clone -b gh-pages https://${GITHUB_PAT}@github.com/${TRAVIS_REPO_SLUG}.git book-output
 cd book-output
 cp -r ../_book/* ./
-## Manual copies to get the icons:
-cp ../images/caution.png ./images
-cp ../images/important.png ./images
-cp ../images/note.png ./images
-cp ../images/tip.png ./images
-cp ../images/warning.png ./images
 git add --all *
 git commit -m"Update the book" || true
 git push -q origin gh-pages

--- a/style.css
+++ b/style.css
@@ -18,17 +18,17 @@ pre code {
   background: #f5f5f5 5px center/3em no-repeat;
 }
 .rmdcaution {
-  background-image: url("../images/caution.png");
+  background-image: url("images/caution.png");
 }
 .rmdimportant {
-  background-image: url("../images/important.png");
+  background-image: url("images/important.png");
 }
 .rmdnote {
-  background-image: url("../images/note.png");
+  background-image: url("images/note.png");
 }
 .rmdtip {
-  background-image: url("../images/tip.png");
+  background-image: url("images/tip.png");
 }
 .rmdwarning {
-  background-image: url("../images/warning.png");
+  background-image: url("images/warning.png");
 }


### PR DESCRIPTION
I had just referred to the icons using the wrong path, which is why we had to manually copy them.

* fixes path
* undoes the manual copy

Should work, but can't tell until it renders on gh-pages.