### PR TITLE
Add Hub Hero to list of commercial JupyterHub providers

### DIFF
--- a/06-getting-your-class-going-with-jupyter.md
+++ b/06-getting-your-class-going-with-jupyter.md
@@ -325,7 +325,7 @@ which provide free trials or a "freemium" pricing model. They include:
     auto-graded assignments.
 
 * HubHero ([https://hubhero.net](https://hubhero.net)) provides dependable
-  JupyterHub servers for teaching professionals. For courses of up to about 30
+  JupyterHub servers for teachers. For courses of up to about 30
   students we offer [the community install](https://hubhero.net/community/) which
   gets you your own JupyterHub on your own hardware or a cloud provider of your
   choice. For larger courses or fully managed deployments

--- a/06-getting-your-class-going-with-jupyter.md
+++ b/06-getting-your-class-going-with-jupyter.md
@@ -326,7 +326,7 @@ which provide free trials or a "freemium" pricing model. They include:
 
 * HubHero ([https://hubhero.net](https://hubhero.net)) provides dependable
   JupyterHub servers for teachers. For courses of up to about 30
-  students we offer [the community install](https://hubhero.net/community/) which
+  students they offer [the community install](https://hubhero.net/community/) which
   gets you your own JupyterHub on your own hardware or a cloud provider of your
   choice. For larger courses or fully managed deployments
   [hosted solutions](https://hubhero.net/hosted/) are available as well. Hub

--- a/06-getting-your-class-going-with-jupyter.md
+++ b/06-getting-your-class-going-with-jupyter.md
@@ -324,6 +324,15 @@ which provide free trials or a "freemium" pricing model. They include:
     like a way to create a course, invite students, and deploy
     auto-graded assignments.
 
+* HubHero ([https://hubhero.net](https://hubhero.net)) provides dependable
+  JupyterHub servers for teaching professionals. For courses of up to about 30
+  students we offer [the community install](https://hubhero.net/community/) which
+  gets you your own JupyterHub on your own hardware or a cloud provider of your
+  choice. For larger courses or fully managed deployments
+  [hosted solutions](https://hubhero.net/hosted/) are available as well. Hub
+  Hero is owned by [Tim Head](https://github.com/betatim/) a project lead for
+  https://mybinder.org and contributor to JupyterHub.
+
 * codio
     ([https://codio.com/features/ide](https://codio.com/features/ide))
 

--- a/06-getting-your-class-going-with-jupyter.md
+++ b/06-getting-your-class-going-with-jupyter.md
@@ -324,8 +324,8 @@ which provide free trials or a "freemium" pricing model. They include:
     like a way to create a course, invite students, and deploy
     auto-graded assignments.
 
-* HubHero ([https://hubhero.net](https://hubhero.net)) provides dependable
-  JupyterHub servers for teachers. For courses of up to about 30
+* HubHero ([https://hubhero.net](https://hubhero.net)) provides professionally
+  configured JupyterHub servers for teachers. For courses of up to about 30
   students they offer [the community install](https://hubhero.net/community/) which
   gets you your own JupyterHub on your own hardware or a cloud provider of your
   choice. For larger courses or fully managed deployments


### PR DESCRIPTION
Hello all!

I could not find the criteria you used to decide which commercial JupyterHub providers to include in the book. I operate https://hubhero.net which provides hubs for teaching professionals and would like to include it in the book.

I clearly have my own interests at mind here and can't make an objective judgement of how appropriate the text and inclusion is -> if you think some of it reads too much like a shameless advert with no substance please suggest how to change it.