### PR TITLE
fix broken doi link

### DIFF
--- a/07-usage-case-studies.md
+++ b/07-usage-case-studies.md
@@ -149,7 +149,7 @@ follow their own pace made a remarkable difference in these learners.
 _REF — Barba, Lorena A., and Forsyth, Gilbert F. (2018). CFD Python:
 the 12 steps to Navier–Stokes equations. Journal of Open Source
 Education, 1(9), 21,
-[https://doi.org/10.21105/jose.0002](https://doi.org/10.21105/jose.0002)
+[https://doi.org/10.21105/jose.00021](https://doi.org/10.21105/jose.00021)
 _
 
 Based on the experience developing the "CFD Python" learning module,


### PR DESCRIPTION
Found broken link by long-winded way: "problematic DOIs reported to CNRI and CrossRef by end users" email to theoj.org email. 